### PR TITLE
Clean init method

### DIFF
--- a/Spinner/Spinner/Spinner.swift
+++ b/Spinner/Spinner/Spinner.swift
@@ -27,7 +27,7 @@ class Spinner: UIView, SLCoreAnimationBuildDelegate {
         }
         
         if animationInfo != nil {
-            let a = SLCoreAnimation.init()
+            let a = SLCoreAnimation()
             a.buildDelegate = self
             a.buildWithInformation(animationInfo!)
             a.play()


### PR DESCRIPTION
I just removed `init()` method for `SLCoreAnimation()` which is not obviously necessary in Swift
