### PR TITLE
Replace callBlockAfter

### DIFF
--- a/AdaptiveTransition/AdaptiveTransition/FromViewController.swift
+++ b/AdaptiveTransition/AdaptiveTransition/FromViewController.swift
@@ -20,11 +20,11 @@ class FromViewController: UIViewController, UIViewControllerTransitioningDelegat
         
         let newViewC = ToViewController(nibName: nil, bundle: nil)
         
-        callBlockAfter({
+        Queue.main(after: 0.5) { 
             newViewC.view.frame = self.view.frame
             newViewC.modalPresentationStyle = .Custom
             self.navigationController?.pushViewController(newViewC, animated: true)
-            }, duration: 0.5)
+        }
         
         
     }

--- a/AdaptiveTransition/AdaptiveTransition/Tools.swift
+++ b/AdaptiveTransition/AdaptiveTransition/Tools.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-func callBlockAfter(block : ()->(), duration : Double) {
-    let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(duration * Double(NSEC_PER_SEC)))
-    dispatch_after(delayTime, dispatch_get_main_queue(), { () -> Void in
-        block()
-    })
+public struct Queue {
+    static func main(after seconds: Double, block: dispatch_block_t) {
+        let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(seconds * Double(NSEC_PER_SEC)))
+        dispatch_after(delayTime, dispatch_get_main_queue(), block)
+    }
 }

--- a/AdaptiveTransition/AdaptiveTransition/TransitionManager.swift
+++ b/AdaptiveTransition/AdaptiveTransition/TransitionManager.swift
@@ -77,10 +77,10 @@ class TransitionManager: NSObject, UIViewControllerAnimatedTransitioning {
                 transitionContext.containerView()?.addSubview(toView!)
                 
                 //calling complete transition right after results in a bad access violation due to the change in layer hierarchy
-                callBlockAfter({
+                Queue.main(after: 0.01) {
                     animation.removeFromSuperlayer()
                     transitionContext.completeTransition(true)
-                }, duration: 0.01)
+                }
             }
         }
     }


### PR DESCRIPTION
I replaced `callBlockAfter` with a new struct `Queue` which simplify the usage and which is more readable.

``` swift
Queue.main(after: 0.5) {
    // Do something
}
```
